### PR TITLE
Fix: GitHub Actions workflow permissions and Node.js deprecation

### DIFF
--- a/.github/workflows/update-action-llama.yml
+++ b/.github/workflows/update-action-llama.yml
@@ -8,12 +8,14 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Check for new version
         id: check


### PR DESCRIPTION
## Summary
Fixes GitHub Actions workflow failure by adding proper permissions and updating Node.js version.

## Changes
- ✅ Added `permissions: contents: write` to allow the workflow to push commits
- ✅ Updated Node.js version from 20 to 24 to resolve deprecation warning
- ✅ Resolves the 403 permission error that was causing the update workflow to fail

## Problem Solved
The "Update action-llama" workflow was failing with:
```
remote: Permission to Action-Llama/agents.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/Action-Llama/agents/': The requested URL returned error: 403
```

## Testing
- The workflow permissions have been explicitly granted
- Node.js 24 is the recommended version going forward
- This should resolve the scheduled dependency update failures

## Related Issue
Closes #12

## Type of Change
- 🐛 Bug fix (non-breaking change which fixes an issue)
- 🔧 Maintenance (dependency updates, CI improvements)