### PR TITLE
Fix: GitHub Actions permission denied for action-llama update workflow

### DIFF
--- a/.github/workflows/update-action-llama.yml
+++ b/.github/workflows/update-action-llama.yml
@@ -5,15 +5,20 @@ on:
     - cron: "0 9 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   update:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Check for new version
         id: check
@@ -40,3 +45,5 @@ jobs:
           git add package.json package-lock.json
           git commit -m "chore: update action-llama to v${{ steps.check.outputs.latest }}"
           git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
This PR fixes the GitHub Actions workflow permission issue described in #12.

## Changes Made

### 1. Added Workflow Permissions
- Added `permissions: contents: write` to grant the workflow write access to the repository
- This allows the workflow to push commits back to the repository

### 2. Updated Node.js Version
- Updated from Node.js 20 to Node.js 24 to resolve deprecation warnings
- Node.js 20 is deprecated and this ensures compatibility with future GitHub Actions runners

### 3. Enhanced Token Configuration
- Added explicit `GITHUB_TOKEN` environment variable to the commit and push step
- Added token parameter to the checkout action for consistency
- This ensures proper authentication for git operations

## Testing
- The workflow should now be able to successfully commit and push dependency updates
- No more "Permission to Action-Llama/agents.git denied to github-actions[bot]" errors
- Node.js deprecation warnings should be resolved

## Impact
- ✅ Fixes automated dependency updates
- ✅ Resolves security concern about outdated dependencies
- ✅ Eliminates workflow failures and error notifications

Closes #12