### PR TITLE
Fix: GitHub Actions permission denied for action-llama update workflow

### DIFF
--- a/.github/workflows/update-action-llama.yml
+++ b/.github/workflows/update-action-llama.yml
@@ -5,15 +5,20 @@ on:
     - cron: "0 9 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   update:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Check for new version
         id: check
@@ -40,3 +45,5 @@ jobs:
           git add package.json package-lock.json
           git commit -m "chore: update action-llama to v${{ steps.check.outputs.latest }}"
           git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
This PR fixes the permission denied error in the 'Update action-llama' workflow by implementing the recommended solution from issue #12.

## Changes Made
- ✅ **Added workflow permissions**: Added `contents: write` permission to allow the workflow to push changes
- ✅ **Updated checkout configuration**: Added `token: ${{ secrets.GITHUB_TOKEN }}` to properly authenticate
- ✅ **Fixed Node.js deprecation**: Updated Node.js version from 20 to 24 to resolve deprecation warnings  
- ✅ **Enhanced git push authentication**: Added `GITHUB_TOKEN` environment variable to the commit and push step

## Solution Approach
This implements **Option 2** from the issue description - configuring repository permissions rather than requiring a new PAT token. This approach:
- Uses the built-in `GITHUB_TOKEN` which is automatically available
- Requires no additional token management
- Follows GitHub's recommended security practices

## Testing
The workflow can be tested by:
1. Merging this PR
2. Manually triggering the 'Update action-llama' workflow via GitHub Actions UI
3. Verifying it completes without permission errors

## Related
Fixes #12

## Risk Assessment
**Low Risk** - This change only grants the minimum required permissions (`contents: write`) to fix the automation workflow. No additional secrets or external access is involved.