### PR TITLE
Fix: gh-actions-responder should add ready-for-dev label to created issues

### DIFF
--- a/agents/gh-actions-responder/ACTIONS.md
+++ b/agents/gh-actions-responder/ACTIONS.md
@@ -26,6 +26,7 @@ If there is no `<webhook-trigger>` block, stop — this agent only operates on w
 
 ```
 gh label create "<issueLabel>" --repo $REPO --color D93F0B --description "Automated CI failure triage" --force
+gh label create "ready-for-dev" --repo $REPO --color 0E8A16 --description "Ready for developer agent" --force
 ```
 
 ## Check if failure is already tracked
@@ -61,7 +62,7 @@ Search the results for an issue referencing the same workflow name. If one exist
    ```
    gh issue create --repo $REPO \
      --title "CI failure: <workflow name> — <brief description of failure>" \
-     --label "<issueLabel>" \
+     --label "<issueLabel>" --label "ready-for-dev" \
      --body "$(cat <<'ISSUE_EOF'
    ## CI Failure Report
 


### PR DESCRIPTION
Closes #16

Modified the gh-actions-responder agent to automatically add the 'ready-for-dev' label when creating issues for CI failures. This allows dev agents to immediately pick up and fix CI failures without needing planner triage.

## Changes
- Added label creation for 'ready-for-dev' in the setup section
- Modified issue creation command to include both 'ci-failure' and 'ready-for-dev' labels

## Testing
This change enables CI failure issues to be immediately actionable by dev agents, streamlining the CI failure resolution workflow.