### PR TITLE
Add ready-for-dev label to CI failure issues

### DIFF
--- a/agents/gh-actions-responder/ACTIONS.md
+++ b/agents/gh-actions-responder/ACTIONS.md
@@ -26,6 +26,7 @@ If there is no `<webhook-trigger>` block, stop — this agent only operates on w
 
 ```
 gh label create "<issueLabel>" --repo $REPO --color D93F0B --description "Automated CI failure triage" --force
+gh label create "ready-for-dev" --repo $REPO --color 0E8A16 --description "Ready for developer agent" --force
 ```
 
 ## Check if failure is already tracked
@@ -61,7 +62,7 @@ Search the results for an issue referencing the same workflow name. If one exist
    ```
    gh issue create --repo $REPO \
      --title "CI failure: <workflow name> — <brief description of failure>" \
-     --label "<issueLabel>" \
+     --label "<issueLabel>" --label "ready-for-dev" \
      --body "$(cat <<'ISSUE_EOF'
    ## CI Failure Report
 


### PR DESCRIPTION
Closes #16

This PR implements the requested changes to make the gh-actions-responder agent automatically add the 'ready-for-dev' label to CI failure issues it creates.

## Changes made:
1. **Added ready-for-dev label setup**: Updated the label creation section to ensure the 'ready-for-dev' label exists in the target repository
2. **Modified issue creation**: Updated the gh issue create command to apply both the existing CI failure label and the new 'ready-for-dev' label

This allows developer agents to immediately pick up CI failures without requiring planner triage, streamlining the fix process.

## Files changed:
- `agents/gh-actions-responder/ACTIONS.md` - Added ready-for-dev label creation and updated issue creation command

The implementation follows the detailed plan provided in the issue comments.