### PR TITLE
Fix CI failure: add allowUnsigned=true to webhook config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,4 +12,5 @@ authType = "api_key"
 
 [webhooks.github]
 type = "github"
+allowUnsigned = true
 


### PR DESCRIPTION
Closes #28

This PR fixes the CI deployment failure by adding `allowUnsigned = true` to the webhook configuration in `config.toml`. This resolves the error:

```
Configuration error: Configuration errors:
  - Webhook source "github" (github) has no credential and allowUnsigned is not set to true.
```

## Changes
- Added `allowUnsigned = true` to `[webhooks.github]` section in `config.toml`

## Notes
This implements Option 2 from the issue description (allowing unsigned webhooks). While less secure than using webhook credentials, this provides an immediate fix for the CI failure. The webhook credentials approach can be implemented later by setting up proper credential configuration in the production environment.