### PR TITLE
fix: Configure action-llama credentials properly in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,5 +37,21 @@ jobs:
           mkdir -p ~/.action-llama/environments
           echo '${{ secrets.DEPLOY_ENV_TOML }}' > ~/.action-llama/environments/prod.toml
 
+      - name: Configure credentials for action-llama
+        run: |
+          # Set up the credential directory
+          mkdir -p ~/.action-llama/credentials
+          
+          # Configure GitHub token
+          echo '{"type":"github_token","token":"${{ secrets.GITHUB_TOKEN }}"}' > ~/.action-llama/credentials/github_token.json
+          
+          # Configure SSH/Git credentials - use the deploy key  
+          GIT_EMAIL="${{ vars.GIT_EMAIL }}"
+          GIT_NAME="${{ vars.GIT_NAME }}"
+          echo '{"type":"git_ssh","privateKey":"${{ secrets.DEPLOY_SSH_KEY }}","email":"'${GIT_EMAIL:-deploy@action-llama.com}'","name":"'${GIT_NAME:-Action Llama Deploy}'"}' > ~/.action-llama/credentials/git_ssh.json
+          
+          # Configure Anthropic API key 
+          echo '{"type":"anthropic_key","key":"${{ secrets.ANTHROPIC_API_KEY }}"}' > ~/.action-llama/credentials/anthropic_key.json
+
       - name: Deploy
         run: npx al push --env prod --headless --no-creds


### PR DESCRIPTION
Closes #32

This PR fixes the CI deployment failure by properly configuring the required credentials for the `npx al push` command.

## Changes

- Added a new step "Configure credentials for action-llama" to the deploy workflow
- Set up three required credentials in the action-llama credential store:
  - `github_token` - GitHub Personal Access Token from secrets.GITHUB_TOKEN
  - `git_ssh` - SSH Key & Git Identity using secrets.DEPLOY_SSH_KEY
  - `anthropic_key` - Anthropic API Credential from secrets.ANTHROPIC_API_KEY

## Root Cause

The `al push` command expects credentials to be configured in the action-llama credential system (`~/.action-llama/credentials/`), but the workflow was only setting up:
- SSH key at `~/.ssh/deploy_key` 
- Environment config at `~/.action-llama/environments/prod.toml`

The `--no-creds` flag means "don't prompt for credentials interactively" but the credentials still need to be present.

## Testing

The workflow should now successfully deploy without the "Credential error: 3 credential(s) missing" error.
