### PR TITLE
Fix CI failure: Remove --no-creds flag from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,4 +58,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           ANTHROPIC_KEY: dummy
           GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
-        run: npx al push --env prod --headless --no-creds
+        run: npx al push --env prod --headless


### PR DESCRIPTION
Closes #36

This PR fixes the CI failure in the Deploy workflow by removing the `--no-creds` flag from the deploy command.

## Problem
The workflow was configured to set up credentials in step 7 but then used the `--no-creds` flag in the deploy step, which explicitly prevented the use of those credentials.

## Solution
Removed the `--no-creds` flag from the deploy command in `.github/workflows/deploy.yml`, allowing the previously configured credentials to be used.

## Changes
- Modified `.github/workflows/deploy.yml` line 51 to remove `--no-creds` flag