### PR TITLE
Fix CI deploy workflow: Replace single quotes with printf for credential file generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,15 +43,15 @@ jobs:
           mkdir -p ~/.action-llama/credentials
           
           # Configure GitHub token
-          echo '{"type":"github_token","token":"${{ secrets.GITHUB_TOKEN }}"}' > ~/.action-llama/credentials/github_token.json
+          printf '{"type":"github_token","token":"%s"}\n' "${{ secrets.GITHUB_TOKEN }}" > ~/.action-llama/credentials/github_token.json
           
           # Configure SSH/Git credentials - use the deploy key  
           GIT_EMAIL="${{ vars.GIT_EMAIL }}"
           GIT_NAME="${{ vars.GIT_NAME }}"
-          echo '{"type":"git_ssh","privateKey":"${{ secrets.DEPLOY_SSH_KEY }}","email":"'${GIT_EMAIL:-deploy@action-llama.com}'","name":"'${GIT_NAME:-Action Llama Deploy}'"}' > ~/.action-llama/credentials/git_ssh.json
+          printf '{"type":"git_ssh","privateKey":"%s","email":"%s","name":"%s"}\n' "${{ secrets.DEPLOY_SSH_KEY }}" "${GIT_EMAIL:-deploy@action-llama.com}" "${GIT_NAME:-Action Llama Deploy}" > ~/.action-llama/credentials/git_ssh.json
           
           # Configure Anthropic API key 
-          echo '{"type":"anthropic_key","key":"${{ secrets.ANTHROPIC_API_KEY }}"}' > ~/.action-llama/credentials/anthropic_key.json
+          printf '{"type":"anthropic_key","key":"%s"}\n' "${{ secrets.ANTHROPIC_API_KEY }}" > ~/.action-llama/credentials/anthropic_key.json
 
       - name: Deploy
         env:


### PR DESCRIPTION
Closes #38

## Problem
The deploy workflow was failing because credential JSON files were being written with literal GitHub Actions placeholder strings instead of actual secret values. This was due to using single quotes around the entire JSON string, which prevents GitHub Actions variable substitution.

## Root Cause  
In bash, single quotes prevent all variable expansion. Commands like:
```bash
echo '{"type":"github_token","token":"${{ secrets.GITHUB_TOKEN }}"}'
```
Write the literal string `${{ secrets.GITHUB_TOKEN }}` instead of the actual token value.

## Solution
Replaced echo commands with printf for better readability and reliability:
```bash  
printf '{"type":"github_token","token":"%s"}\n' "${{ secrets.GITHUB_TOKEN }}"
```

This ensures proper parameter substitution for all secrets and variables.

## Changes
- Fixed github_token.json credential generation
- Fixed git_ssh.json credential generation  
- Fixed anthropic_key.json credential generation
- Improved readability with printf format strings

## Testing
- Validated YAML syntax is correct
- No functional changes to workflow logic, only credential generation method

This should resolve the credential validation errors in the deploy workflow.