### PR TITLE
fix: use jq to properly escape SSH key in credential JSON

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,12 @@ jobs:
           # Configure SSH/Git credentials - use the deploy key  
           GIT_EMAIL="${{ vars.GIT_EMAIL }}"
           GIT_NAME="${{ vars.GIT_NAME }}"
-          printf '{"type":"git_ssh","privateKey":"%s","email":"%s","name":"%s"}\n' "${{ secrets.DEPLOY_SSH_KEY }}" "${GIT_EMAIL:-deploy@action-llama.com}" "${GIT_NAME:-Action Llama Deploy}" > ~/.action-llama/credentials/git_ssh.json
+          jq -n \
+            --arg key "${{ secrets.DEPLOY_SSH_KEY }}" \
+            --arg email "${GIT_EMAIL:-deploy@action-llama.com}" \
+            --arg name "${GIT_NAME:-Action Llama Deploy}" \
+            '{"type":"git_ssh","privateKey":$key,"email":$email,"name":$name}' \
+            > ~/.action-llama/credentials/git_ssh.json
           
           # Configure Anthropic API key 
           printf '{"type":"anthropic_key","key":"%s"}\n' "${{ secrets.ANTHROPIC_API_KEY }}" > ~/.action-llama/credentials/anthropic_key.json


### PR DESCRIPTION
Closes #44

## Description

This PR fixes the CI deployment failure by replacing the problematic `printf` command with `jq` to properly construct the `git_ssh.json` credential file.

## Problem

The deployment workflow was failing because SSH private keys contain newlines and special characters that break JSON formatting when interpolated directly with `%s` in printf. This created malformed JSON that the action-llama CLI could not parse.

## Solution

Replaced the printf command with jq to properly escape SSH keys, emails, and names when constructing the JSON credential file.

## Testing

This change ensures that:
- SSH private keys are properly escaped for JSON
- Multi-line strings and special characters are handled correctly
- The credential file will contain valid JSON that can be parsed by action-llama CLI

The fix follows the exact suggestion from the issue description.