### PR TITLE
Fix CI failure: Remove incorrect HOME environment variable setting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -145,8 +145,6 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # Ensure proper Git SSH setup
           GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key"
-          # Explicitly set HOME to ensure al CLI looks in the right place
-          HOME: ${{ env.HOME }}
         run: |
           echo "=== Final pre-deploy checks ==="
           echo "HOME: $HOME"


### PR DESCRIPTION
Closes #48

This PR fixes the CI failure in the Deploy workflow by removing the incorrect HOME environment variable setting.

The problematic line `HOME: ${{ env.HOME }}` was setting HOME to an empty string because env.HOME doesn't exist in GitHub Actions context. This caused the al CLI to look for configuration files in the wrong location.

With this fix, GitHub Actions will use the default HOME (/home/runner) which is correct.