### PR TITLE
Fix: Make ANTHROPIC_API_KEY optional for headless deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,15 +64,15 @@ jobs:
           
           MISSING_SECRETS=""
           SETUP_SCORE=0
-          TOTAL_SECRETS=4
+          TOTAL_SECRETS=3
+          OPTIONAL_SECRETS=0
           
-          # Check if ANTHROPIC_API_KEY is set and not empty
+          # Check if ANTHROPIC_API_KEY is set (optional for headless deployments)
           if [ -z "${{ secrets.ANTHROPIC_API_KEY }}" ]; then
-            echo "❌ ERROR: ANTHROPIC_API_KEY repository secret is not set or is empty"
-            MISSING_SECRETS="$MISSING_SECRETS ANTHROPIC_API_KEY"
+            echo "⚠️  INFO: ANTHROPIC_API_KEY repository secret is not set (optional for headless deployments)"
           else
             echo "✅ ANTHROPIC_API_KEY secret is set"
-            SETUP_SCORE=$((SETUP_SCORE + 1))
+            OPTIONAL_SECRETS=$((OPTIONAL_SECRETS + 1))
           fi
           
           # Check if DEPLOY_SSH_KEY is set  
@@ -103,7 +103,7 @@ jobs:
           fi
           
           echo ""
-          echo "📊 SETUP STATUS: ${SETUP_SCORE}/${TOTAL_SECRETS} secrets configured"
+          echo "📊 SETUP STATUS: ${SETUP_SCORE}/${TOTAL_SECRETS} required secrets configured, ${OPTIONAL_SECRETS}/1 optional secrets configured"
           
           # If any secrets are missing, provide enhanced guidance
           if [ -n "$MISSING_SECRETS" ]; then
@@ -116,9 +116,10 @@ jobs:
               echo "🔑 $secret:"
               case $secret in
                 "ANTHROPIC_API_KEY")
-                  echo "   Purpose: API access for Claude AI models"
+                  echo "   Purpose: API access for Claude AI models (optional for headless deployments)"
                   echo "   Get key: https://console.anthropic.com/account/keys"
                   echo "   Format: Starts with 'sk-ant-'"
+                  echo "   Note: This deployment uses --headless mode, so this key is optional"
                   ;;
                 "DEPLOY_SSH_KEY")
                   echo "   Purpose: SSH access for deployment to production"
@@ -229,7 +230,7 @@ jobs:
               if [ -n "${{ secrets.ANTHROPIC_API_KEY }}" ]; then
                 printf '{"type":"anthropic_key","key":"%s"}\n' "${{ secrets.ANTHROPIC_API_KEY }}" > "${cred_dir}/anthropic_key.json"
               else
-                echo '{"type":"anthropic_key","key":"dry-run-placeholder"}' > "${cred_dir}/anthropic_key.json"
+                echo "ℹ️  ANTHROPIC_API_KEY not set, skipping anthropic credential file (headless mode)"
               fi
             else
               # Normal credential setup
@@ -246,8 +247,13 @@ jobs:
                 '{"type":"git_ssh","privateKey":$key,"email":$email,"name":$name}' \
                 > "${cred_dir}/git_ssh.json"
               
-              # Configure Anthropic API key 
-              printf '{"type":"anthropic_key","key":"%s"}\n' "${{ secrets.ANTHROPIC_API_KEY }}" > "${cred_dir}/anthropic_key.json"
+              # Configure Anthropic API key (only if provided)
+              if [ -n "${{ secrets.ANTHROPIC_API_KEY }}" ]; then
+                printf '{"type":"anthropic_key","key":"%s"}\n' "${{ secrets.ANTHROPIC_API_KEY }}" > "${cred_dir}/anthropic_key.json"
+                echo "✅ Anthropic API key configured"
+              else
+                echo "ℹ️  ANTHROPIC_API_KEY not provided, skipping (optional for headless deployments)"
+              fi
             fi
             
             # Set proper permissions on all credential files
@@ -342,9 +348,10 @@ jobs:
         env:
           # Set environment variables as fallbacks for credentials
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           AL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AL_ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Only set Anthropic keys if the secret is provided (optional for headless deployments)
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || '' }}
+          AL_ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY || '' }}
           # Ensure proper Git SSH setup
           GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key"
           # Try alternative credential directory paths
@@ -372,13 +379,14 @@ jobs:
           echo "HOME: $HOME"
           echo "Current directory: $(pwd)"
           
-          # Double-check that our secrets are actually populated
-          if [ -z "$ANTHROPIC_API_KEY" ]; then
-            echo "❌ FATAL: ANTHROPIC_API_KEY environment variable is empty"
-            exit 1
+          # Check environment variables (ANTHROPIC_API_KEY is optional for headless deployments)
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
+            echo "✅ ANTHROPIC_API_KEY is available"
+          else
+            echo "ℹ️  ANTHROPIC_API_KEY not provided (optional for headless deployments)"
           fi
           
-          echo "✅ Required environment variables are set"
+          echo "✅ Environment setup complete"
           
           # Try multiple approaches for credential detection
           echo "=== Final credential check ==="
@@ -407,11 +415,16 @@ jobs:
           
           if [ "$CREDS_FOUND" = "false" ]; then
             echo "⚠️  Credential files not detected by al CLI, relying on environment variables"
-            # Verify environment variables are set as fallback
-            if [ -n "$AL_GITHUB_TOKEN" ] && [ -n "$AL_ANTHROPIC_KEY" ]; then
-              echo "✅ Environment variable fallbacks are configured"
+            # Verify environment variables are set as fallback (ANTHROPIC_API_KEY is optional)
+            if [ -n "$AL_GITHUB_TOKEN" ]; then
+              echo "✅ GitHub token environment variable is configured"
+              if [ -n "$AL_ANTHROPIC_KEY" ]; then
+                echo "✅ Anthropic API key environment variable is configured"
+              else
+                echo "ℹ️  Anthropic API key not provided (optional for headless deployments)"
+              fi
             else
-              echo "❌ Neither credential files nor environment variables are working"
+              echo "❌ GitHub token environment variable is missing"
               echo "This deploy will likely fail, but attempting anyway for diagnostic purposes"
             fi
           fi
@@ -431,9 +444,9 @@ jobs:
             done
             echo "Environment variables:"
             echo "  GITHUB_TOKEN: $([ -n "$GITHUB_TOKEN" ] && echo "set" || echo "not set")"
-            echo "  ANTHROPIC_API_KEY: $([ -n "$ANTHROPIC_API_KEY" ] && echo "set" || echo "not set")"
+            echo "  ANTHROPIC_API_KEY: $([ -n "$ANTHROPIC_API_KEY" ] && echo "set" || echo "not set (optional for headless)")"
             echo "  AL_GITHUB_TOKEN: $([ -n "$AL_GITHUB_TOKEN" ] && echo "set" || echo "not set")" 
-            echo "  AL_ANTHROPIC_KEY: $([ -n "$AL_ANTHROPIC_KEY" ] && echo "set" || echo "not set")"
+            echo "  AL_ANTHROPIC_KEY: $([ -n "$AL_ANTHROPIC_KEY" ] && echo "set" || echo "not set (optional for headless)")"
             exit 1
           }
           

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ The quick setup will guide you through configuring all required secrets for depl
 
 Before the deployment workflow can run successfully, the following repository secrets must be configured in GitHub:
 
-1. **ANTHROPIC_API_KEY** ⚠️ **Required**
+1. **ANTHROPIC_API_KEY** ⚠️ **Required** (optional for headless deployments)
    - Valid Anthropic API key for Claude models
    - Used by agents for AI model access
+   - **Note**: Since this deployment uses `--headless` mode, this key is optional
    - Set at: https://github.com/Action-Llama/agents/settings/secrets/actions
 
 2. **DEPLOY_SSH_KEY** ⚠️ **Required**
@@ -80,7 +81,7 @@ The deployment workflow runs automatically on pushes to `main`. It:
 
 ### Troubleshooting Deployment
 
-**"ANTHROPIC_API_KEY secret not set"**: This means the required repository secret is missing. Repository administrators should:
+**"ANTHROPIC_API_KEY secret not set"**: This key is optional for headless deployments (which is the default), but if you need it for other purposes, repository administrators should:
 1. **Quick fix**: Run the focused fix tool: `GITHUB_TOKEN=your_token npm run fix-anthropic-key`
 2. **General CI issues**: Run the CI failure resolver: `GITHUB_TOKEN=your_token npm run resolve-ci-failure`
 3. **Interactive setup**: Run the setup assistant: `GITHUB_TOKEN=your_token npm run setup`

--- a/SETUP-CHECKLIST.md
+++ b/SETUP-CHECKLIST.md
@@ -25,12 +25,13 @@ The setup assistant will:
 
 ## Required Repository Secrets
 
-The following secrets **must** be configured for the deployment workflow to succeed:
+The following secrets are needed for the deployment workflow. ANTHROPIC_API_KEY is optional for headless deployments (the default mode):
 
-### ✅ ANTHROPIC_API_KEY
+### ✅ ANTHROPIC_API_KEY (Optional for headless deployments)
 
 - **Description**: Valid Anthropic API key for Claude models
 - **Purpose**: Used by agents for AI model access
+- **Note**: Optional when deploying with `--headless` flag (which is the default)
 - **Setup**: 
   1. Obtain an API key from [Anthropic Console](https://console.anthropic.com/)
   2. Go to [Repository Secrets](https://github.com/Action-Llama/agents/settings/secrets/actions)
@@ -130,10 +131,10 @@ git push
 ### Manual Validation
 
 1. Go to [Repository Secrets](https://github.com/Action-Llama/agents/settings/secrets/actions)
-2. Verify all required secrets are listed:
-   - ✅ ANTHROPIC_API_KEY
-   - ✅ DEPLOY_SSH_KEY  
-   - ✅ DEPLOY_ENV_TOML
+2. Verify required secrets are listed:
+   - ✅ DEPLOY_SSH_KEY (required)
+   - ✅ DEPLOY_ENV_TOML (required)
+   - ⚠️ ANTHROPIC_API_KEY (optional for headless deployments)
 3. Check that secret values are not empty
 4. Test by triggering the deployment workflow
 

--- a/scripts/test-deploy-workflow.js
+++ b/scripts/test-deploy-workflow.js
@@ -62,8 +62,8 @@ try {
 
 // Test 3: Check environment variable setup
 console.log('\n3️⃣  Checking environment variables...');
-const requiredEnvVars = ['GITHUB_TOKEN', 'ANTHROPIC_API_KEY'];
-const optionalEnvVars = ['GIT_EMAIL', 'GIT_NAME'];
+const requiredEnvVars = ['GITHUB_TOKEN'];
+const optionalEnvVars = ['ANTHROPIC_API_KEY', 'GIT_EMAIL', 'GIT_NAME'];
 
 let missingRequired = [];
 for (const varName of requiredEnvVars) {
@@ -102,13 +102,6 @@ try {
       }, null, 2)
     },
     {
-      name: 'anthropic_key.json', 
-      content: JSON.stringify({
-        type: 'anthropic_key',
-        key: process.env.ANTHROPIC_API_KEY || 'test-key'
-      }, null, 2)
-    },
-    {
       name: 'git_ssh.json',
       content: JSON.stringify({
         type: 'git_ssh',
@@ -118,6 +111,17 @@ try {
       }, null, 2)
     }
   ];
+
+  // Only create anthropic_key.json if ANTHROPIC_API_KEY is provided
+  if (process.env.ANTHROPIC_API_KEY) {
+    credentials.push({
+      name: 'anthropic_key.json', 
+      content: JSON.stringify({
+        type: 'anthropic_key',
+        key: process.env.ANTHROPIC_API_KEY
+      }, null, 2)
+    });
+  }
   
   for (const cred of credentials) {
     const filePath = join(testCredDir, cred.name);

--- a/scripts/validate-secrets.js
+++ b/scripts/validate-secrets.js
@@ -18,11 +18,6 @@ import { exit } from 'process';
 
 const REQUIRED_SECRETS = [
   {
-    name: 'ANTHROPIC_API_KEY',
-    description: 'Valid Anthropic API key for Claude models',
-    required: true
-  },
-  {
     name: 'DEPLOY_SSH_KEY', 
     description: 'SSH private key for deployment access',
     required: true
@@ -31,6 +26,14 @@ const REQUIRED_SECRETS = [
     name: 'DEPLOY_ENV_TOML',
     description: 'Production environment configuration',
     required: true
+  }
+];
+
+const OPTIONAL_SECRETS = [
+  {
+    name: 'ANTHROPIC_API_KEY',
+    description: 'Valid Anthropic API key for Claude models (optional for headless deployments)',
+    required: false
   }
 ];
 
@@ -82,7 +85,7 @@ async function checkSecrets(repo, token) {
 
   console.log(`🔍 Checking repository secrets for ${repo}...\n`);
 
-  let allConfigured = true;
+  let allRequiredConfigured = true;
   
   // Check required secrets
   console.log('📋 Required Secrets:');
@@ -97,7 +100,31 @@ async function checkSecrets(repo, token) {
       } else if (response.status === 404) {
         console.log(`   ❌ ${secret.name} - NOT CONFIGURED`);
         console.log(`      ${secret.description}`);
-        allConfigured = false;
+        allRequiredConfigured = false;
+      } else {
+        console.log(`   ⚠️  ${secret.name} - could not verify (status: ${response.status})`);
+        if (response.status === 403) {
+          console.log(`      Your GitHub token may not have the required permissions.`);
+        }
+      }
+    } catch (error) {
+      console.log(`   ⚠️  ${secret.name} - error checking: ${error.message}`);
+    }
+  }
+
+  // Check optional secrets
+  console.log('\n📋 Optional Secrets:');
+  for (const secret of OPTIONAL_SECRETS) {
+    try {
+      const response = await fetch(`https://api.github.com/repos/${repo}/actions/secrets/${secret.name}`, {
+        headers
+      });
+      
+      if (response.status === 200) {
+        console.log(`   ✅ ${secret.name} - configured`);
+      } else if (response.status === 404) {
+        console.log(`   ⚪ ${secret.name} - not configured (optional)`);
+        console.log(`      ${secret.description}`);
       } else {
         console.log(`   ⚠️  ${secret.name} - could not verify (status: ${response.status})`);
         if (response.status === 403) {
@@ -130,7 +157,7 @@ async function checkSecrets(repo, token) {
     }
   }
 
-  return allConfigured;
+  return allRequiredConfigured;
 }
 
 function printSetupInstructions(repo) {


### PR DESCRIPTION
Closes #66

## Summary

This PR addresses the issue where the Deploy workflow failed due to missing ANTHROPIC_API_KEY even though it should not be required for headless deployments.

## Changes Made

### Workflow Updates ()
- **Secret validation**: Made ANTHROPIC_API_KEY optional, changing required secret count from 4 to 3 + 1 optional
- **Credential configuration**: Only create  file when the API key is actually provided
- **Deploy step**: Removed the check that fails deployment when ANTHROPIC_API_KEY is missing
- **Environment variables**: Only set Anthropic-related env vars if the secret exists
- **Error messaging**: Updated guidance to clarify the key is optional for headless deployments

### Documentation Updates
- **README.md**: Updated ANTHROPIC_API_KEY description to show it's optional for headless deployments
- **SETUP-CHECKLIST.md**: Clarified that ANTHROPIC_API_KEY is conditionally required

### Script Updates
- **validate-secrets.js**: Moved ANTHROPIC_API_KEY to optional secrets list
- **test-deploy-workflow.js**: Made ANTHROPIC_API_KEY optional in environment variable checks

## Impact

✅ **Deployments will now succeed** without ANTHROPIC_API_KEY since the workflow always uses  flag
✅ **Backward compatibility maintained** - workflows with the key configured will continue to work
✅ **Clear documentation** helps users understand when the key is needed vs optional
✅ **All validation tools updated** to reflect the new optional status

## Testing

- ✅ Local test workflow passes ()
- ✅ Secret validation passes with only required secrets ()
- ✅ Pre-commit checks pass ()

The deploy workflow will now succeed for headless deployments without requiring ANTHROPIC_API_KEY configuration.