### PR TITLE
Update deploy workflow to install latest Action Llama before deploying

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,9 @@ concurrency:
   group: deploy
   cancel-in-progress: false
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -31,6 +34,52 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Update Action Llama
+        id: update-al
+        run: |
+          # Sleep briefly when triggered by repository_dispatch to allow npm propagation
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            echo "Waiting for npm registry..."
+            sleep 10
+          fi
+
+          CURRENT=$(node -p "require('./package.json').dependencies['@action-llama/action-llama']")
+          CURRENT_VERSION="${CURRENT#^}"
+
+          LATEST_NEXT=$(npm view @action-llama/action-llama@next version 2>/dev/null || echo "")
+          LATEST_STABLE=$(npm view @action-llama/action-llama version)
+
+          if [ -n "$LATEST_NEXT" ] && echo "$CURRENT_VERSION" | grep -q "^0\.1[0-9]"; then
+            TARGET_VERSION="$LATEST_NEXT"
+            TARGET_TAG="next"
+          else
+            TARGET_VERSION="$LATEST_STABLE"
+            TARGET_TAG="latest"
+          fi
+
+          if [ "$CURRENT_VERSION" != "$TARGET_VERSION" ]; then
+            echo "Updating @action-llama/action-llama from $CURRENT_VERSION to $TARGET_VERSION ($TARGET_TAG)"
+            if [ "$TARGET_TAG" = "next" ]; then
+              npm install @action-llama/action-llama@$TARGET_TAG
+            else
+              npm install @action-llama/action-llama@^$TARGET_VERSION
+            fi
+            echo "updated=true" >> $GITHUB_OUTPUT
+            echo "version=$TARGET_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "Action Llama is already up to date ($CURRENT_VERSION)"
+            echo "updated=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit updated Action Llama
+        if: steps.update-al.outputs.updated == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore: update action-llama to v${{ steps.update-al.outputs.version }}"
+          git push origin main
 
       - name: Set up SSH key
         run: |


### PR DESCRIPTION
Closes #83

## Changes

Updated `.github/workflows/deploy.yml` to automatically check for and install the latest version of `@action-llama/action-llama` before deploying, then commit the dependency change back to `main`.

### What changed

1. **Added `permissions: contents: write`** — required so the workflow can push updated `package.json`/`package-lock.json` back to `main`.

2. **Added "Update Action Llama" step** (after `npm ci`, before SSH setup):
   - Sleeps 10 seconds only when triggered via `repository_dispatch` (to allow npm registry propagation after a publish)
   - Reads current version from `package.json`
   - Checks `next` or `latest` tag based on current version track (mirrors logic from `update-action-llama.yml`)
   - Installs the new version if it differs from the current one

3. **Added "Commit updated Action Llama" step** (conditional on update):
   - Commits and pushes `package.json` and `package-lock.json` to `main` using `github-actions[bot]`
   - Only runs when an update was actually installed

### Step order after changes
1. `actions/checkout@v4`
2. `actions/setup-node@v4`
3. Install dependencies (`npm ci`)
4. **Update Action Llama** ← NEW
5. **Commit updated Action Llama** ← NEW (conditional)
6. Set up SSH key *(existing)*
7. ... rest of existing deploy steps