### PR TITLE
fix: Deploy step now fails when push fails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -420,6 +420,7 @@ jobs:
           # The al CLI will read credentials from ~/.action-llama/credentials
           # --no-creds skips credential validation so missing optional creds don't block the deploy
           echo "Running: npx al push --env prod --headless --no-creds"
+          set -o pipefail
           if npx al push --env prod --headless --no-creds 2>&1 | tee deploy.log; then
             echo "✅ Deploy completed successfully"
           else


### PR DESCRIPTION
Closes #87

## Problem

The `Deploy` step in the workflow used a pipe:
```bash
if npx al push --env prod --headless --no-creds 2>&1 | tee deploy.log; then
```

When `npx al push` fails (non-zero exit code), the pipe returns the exit code of `tee` (the last command), which is always `0` (success). So the `if` branch evaluated as success and printed "✅ Deploy completed successfully" even when the deploy had failed.

## Fix

Added `set -o pipefail` before the pipe command. With `pipefail` enabled, the pipe returns the exit code of the first failed command in the pipeline, so a failing `npx al push` will now correctly cause the step to fail.